### PR TITLE
Add File History shortcut on prints files changed (#9)

### DIFF
--- a/src/Command/TemplateChangesCommand.php
+++ b/src/Command/TemplateChangesCommand.php
@@ -159,7 +159,7 @@ final class TemplateChangesCommand extends Command
         foreach ($overriddenTemplateFiles as $file) {
             $checkFilesHistoryUrl = $this->getCheckFilesHistoryUrlFromBundleFilePath($file);
             $this->writeLine("\t" . sprintf(
-                '%s [Check file\'s history: %s]',
+                '%s [<href=%s>Check file\'s history</>]',
                 $file,
                 $checkFilesHistoryUrl
             ));
@@ -210,7 +210,7 @@ final class TemplateChangesCommand extends Command
         foreach ($overriddenTemplateFiles as $file) {
             $checkFilesHistoryUrl = $this->getCheckFilesHistoryUrlFromBundleFilePath($file);
             $this->writeLine("\t" . sprintf(
-                '%s [Check file\'s history: %s]',
+                '%s [<href=%s>Check file\'s history</>]',
                 $file,
                 $checkFilesHistoryUrl
             ));

--- a/src/Command/TemplateChangesCommand.php
+++ b/src/Command/TemplateChangesCommand.php
@@ -157,7 +157,12 @@ final class TemplateChangesCommand extends Command
 
         $this->writeLine(sprintf('Found %s files that changed and was overridden:', count($overriddenTemplateFiles)));
         foreach ($overriddenTemplateFiles as $file) {
-            $this->writeLine("\t" . $file);
+            $checkFilesHistoryUrl = $this->getCheckFilesHistoryUrlFromBundleFilePath($file);
+            $this->writeLine("\t" . sprintf(
+                '%s [Check file\'s history: %s]',
+                $file,
+                $checkFilesHistoryUrl
+            ));
         }
     }
 
@@ -203,7 +208,12 @@ final class TemplateChangesCommand extends Command
 
         $this->writeLine(sprintf('Found %s files that changed and was overridden:', count($overriddenTemplateFiles)));
         foreach ($overriddenTemplateFiles as $file) {
-            $this->writeLine("\t" . $file);
+            $checkFilesHistoryUrl = $this->getCheckFilesHistoryUrlFromBundleFilePath($file);
+            $this->writeLine("\t" . sprintf(
+                '%s [Check file\'s history: %s]',
+                $file,
+                $checkFilesHistoryUrl
+            ));
         }
     }
 
@@ -230,5 +240,22 @@ final class TemplateChangesCommand extends Command
             return;
         }
         $this->output->writeln($message);
+    }
+
+    private function getFilePathWithBundle(string $file): string
+    {
+        if (false === $pos = strpos($file, '/')) {
+            return $file;
+        }
+        $bundle = substr($file, 0, $pos);
+        $file = substr($file, $pos + 1);
+        $bundle = str_replace('Sylius', '', $bundle);
+
+        return $bundle . '/Resources/views/' . $file;
+    }
+
+    private function getCheckFilesHistoryUrlFromBundleFilePath(string $file): string
+    {
+        return 'https://github.com/Sylius/Sylius/commits/master/src/Sylius/Bundle/' . $this->getFilePathWithBundle($file);
     }
 }

--- a/src/Command/TemplateChangesCommand.php
+++ b/src/Command/TemplateChangesCommand.php
@@ -35,6 +35,10 @@ final class TemplateChangesCommand extends Command
     /** @var GitInterface */
     private $gitClient;
 
+    private string $toVersion;
+
+    private string $fromVersion;
+
     public function __construct(GitInterface $gitClient, string $rootPath, string $name = null)
     {
         parent::__construct($name);
@@ -82,13 +86,15 @@ final class TemplateChangesCommand extends Command
         if (!is_string($fromVersion) || trim($fromVersion) === '') {
             throw new \RuntimeException(sprintf('Argument "%s" is not a valid non-empty string', self::FROM_VERSION_ARGUMENT_NAME));
         }
+        $this->fromVersion = $fromVersion;
 
         $toVersion = $input->getArgument(self::TO_VERSION_ARGUMENT_NAME);
         if (!is_string($toVersion) || trim($toVersion) === '') {
             throw new \RuntimeException(sprintf('Argument "%s" is not a valid non-empty string', self::TO_VERSION_ARGUMENT_NAME));
         }
+        $this->toVersion = $toVersion;
 
-        $versionChangedFiles = $this->getFilesChangedBetweenTwoVersions($fromVersion, $toVersion);
+        $versionChangedFiles = $this->getFilesChangedBetweenTwoVersions();
         $this->computeTemplateFilesChangedAndOverridden($versionChangedFiles);
 
         /** @var mixed $themeName */
@@ -104,10 +110,10 @@ final class TemplateChangesCommand extends Command
     /**
      * @return string[]
      */
-    private function getFilesChangedBetweenTwoVersions(string $fromVersion, string $toVersion): array
+    private function getFilesChangedBetweenTwoVersions(): array
     {
-        $this->writeLine(sprintf('Computing differences between %s and %s', $fromVersion, $toVersion));
-        $diff = $this->gitClient->getDiffBetweenTags($fromVersion, $toVersion);
+        $this->writeLine(sprintf('Computing differences between %s and %s', $this->fromVersion, $this->toVersion));
+        $diff = $this->gitClient->getDiffBetweenTags($this->fromVersion, $this->toVersion);
         $versionChangedFiles = [];
         $diffLines = explode(\PHP_EOL, $diff);
         foreach ($diffLines as $diffLine) {
@@ -256,6 +262,6 @@ final class TemplateChangesCommand extends Command
 
     private function getCheckFilesHistoryUrlFromBundleFilePath(string $file): string
     {
-        return 'https://github.com/Sylius/Sylius/commits/master/src/Sylius/Bundle/' . $this->getFilePathWithBundle($file);
+        return 'https://github.com/Sylius/Sylius/commits/' . $this->toVersion . '/src/Sylius/Bundle/' . $this->getFilePathWithBundle($file);
     }
 }

--- a/tests/Integration/Command/TemplateChangesCommandTest.php
+++ b/tests/Integration/Command/TemplateChangesCommandTest.php
@@ -88,8 +88,8 @@ Computing differences between 1.8.4 and 1.8.8
 
 Searching "vfs://root/templates/bundles/" for overridden files that changed between the two versions.
 Found 2 files that changed and was overridden:
-	SyliusShopBundle/Checkout/Address/_form.html.twig [Check file's history: https://github.com/Sylius/Sylius/commits/master/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Address/_form.html.twig]
-	SyliusUiBundle/Form/theme.html.twig [Check file's history: https://github.com/Sylius/Sylius/commits/master/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig]
+	SyliusShopBundle/Checkout/Address/_form.html.twig [Check file's history]
+	SyliusUiBundle/Form/theme.html.twig [Check file's history]
 
 TXT;
 
@@ -123,9 +123,9 @@ Found 0 files that changed and was overridden.
 
 Searching "vfs://root/themes/my-theme/" for overridden files that changed between the two versions.
 Found 3 files that changed and was overridden:
-	SyliusShopBundle/Checkout/_header.html.twig [Check file's history: https://github.com/Sylius/Sylius/commits/master/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_header.html.twig]
-	SyliusUiBundle/Form/theme.html.twig [Check file's history: https://github.com/Sylius/Sylius/commits/master/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig]
-	SyliusAdminBundle/Product/_mainImage.html.twig [Check file's history: https://github.com/Sylius/Sylius/commits/master/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_mainImage.html.twig]
+	SyliusShopBundle/Checkout/_header.html.twig [Check file's history]
+	SyliusUiBundle/Form/theme.html.twig [Check file's history]
+	SyliusAdminBundle/Product/_mainImage.html.twig [Check file's history]
 
 TXT;
 
@@ -212,8 +212,8 @@ Found 0 files that changed and was overridden.
 
 Searching "vfs://root/themes/my-theme/templates/bundles/" for overridden files that changed between the two versions.
 Found 2 files that changed and was overridden:
-	SyliusShopBundle/Checkout/_header.html.twig [Check file's history: https://github.com/Sylius/Sylius/commits/master/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_header.html.twig]
-	SyliusUiBundle/Form/theme.html.twig [Check file's history: https://github.com/Sylius/Sylius/commits/master/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig]
+	SyliusShopBundle/Checkout/_header.html.twig [Check file's history]
+	SyliusUiBundle/Form/theme.html.twig [Check file's history]
 
 TXT;
 

--- a/tests/Integration/Command/TemplateChangesCommandTest.php
+++ b/tests/Integration/Command/TemplateChangesCommandTest.php
@@ -88,8 +88,8 @@ Computing differences between 1.8.4 and 1.8.8
 
 Searching "vfs://root/templates/bundles/" for overridden files that changed between the two versions.
 Found 2 files that changed and was overridden:
-	SyliusShopBundle/Checkout/Address/_form.html.twig
-	SyliusUiBundle/Form/theme.html.twig
+	SyliusShopBundle/Checkout/Address/_form.html.twig [Check file's history: https://github.com/Sylius/Sylius/commits/master/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Address/_form.html.twig]
+	SyliusUiBundle/Form/theme.html.twig [Check file's history: https://github.com/Sylius/Sylius/commits/master/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig]
 
 TXT;
 
@@ -123,9 +123,9 @@ Found 0 files that changed and was overridden.
 
 Searching "vfs://root/themes/my-theme/" for overridden files that changed between the two versions.
 Found 3 files that changed and was overridden:
-	SyliusShopBundle/Checkout/_header.html.twig
-	SyliusUiBundle/Form/theme.html.twig
-	SyliusAdminBundle/Product/_mainImage.html.twig
+	SyliusShopBundle/Checkout/_header.html.twig [Check file's history: https://github.com/Sylius/Sylius/commits/master/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_header.html.twig]
+	SyliusUiBundle/Form/theme.html.twig [Check file's history: https://github.com/Sylius/Sylius/commits/master/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig]
+	SyliusAdminBundle/Product/_mainImage.html.twig [Check file's history: https://github.com/Sylius/Sylius/commits/master/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_mainImage.html.twig]
 
 TXT;
 
@@ -212,8 +212,8 @@ Found 0 files that changed and was overridden.
 
 Searching "vfs://root/themes/my-theme/templates/bundles/" for overridden files that changed between the two versions.
 Found 2 files that changed and was overridden:
-	SyliusShopBundle/Checkout/_header.html.twig
-	SyliusUiBundle/Form/theme.html.twig
+	SyliusShopBundle/Checkout/_header.html.twig [Check file's history: https://github.com/Sylius/Sylius/commits/master/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_header.html.twig]
+	SyliusUiBundle/Form/theme.html.twig [Check file's history: https://github.com/Sylius/Sylius/commits/master/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig]
 
 TXT;
 


### PR DESCRIPTION
It is not possible to make a diff of a file between two tags on GitHub. It is been possible to make something similar with some chrome/firefox extensions, but I'm not sure it is possible to use them with very big diffs.
So, I just added a link to the file's history, it's better than nothing 😄 .