### PR TITLE
Allow more sylius versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "require": {
     "php": "^7.4 || ^8.0",
-    "sylius/sylius": "~1.9.0 || ~1.10.0@beta",
+    "sylius/sylius": "^1.9",
     "webmozart/glob": "^4.3"
   },
   "require-dev": {


### PR DESCRIPTION
As this plugin is used to upgrade Sylius to newer version I think it should have a less strict `sylius/sylius` version requirement.