### PR TITLE
Allow sylius/sylius ^1.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.0",
-        "sylius/sylius": "^1.11.2 || ^1.12.0-alpha.1",
+        "sylius/sylius": "^1.11.2 || ^1.12",
         "webmozart/glob": "^4.3"
     },
     "require-dev": {


### PR DESCRIPTION
I'm not sure if things break this way, but I would like to try the plugin on upgrading our project to Sylius v1.12 and this plugin has been very useful until now :-)